### PR TITLE
Adding a default README to the org layer repo

### DIFF
--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -61,6 +61,8 @@ module "foundations_github_organization" {
   gcp_tf_state_bucket_project_id = module.github_gcloud_oidc.project_id
   bucket_name                    = module.github_gcloud_oidc.bucket_name
   bucket_location                = module.github_gcloud_oidc.bucket_location
+
+  readme_path = "${path.root}/organizations/projects/README.md"
 }
 
 resource "github_enterprise_organization" "organization" {

--- a/bootstrap/terraform.tfvars
+++ b/bootstrap/terraform.tfvars
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Must include the domain of the organization you are deploying the foundation.
+
+org_id = "942835104931"
+
+billing_account = "01D3BD-1853C8-C675FF"
+
+github_enterprise_slug = "foci-solutions"
+
+github_foundations_organization_name = "foci-github-foundations"
+
+github_organization_admin_logins = ["blastdan", "bzarboni1", "TylerMizuyabu"]
+
+github_organization_billing_email = "dan.mccrady@focisolutions.com"

--- a/organizations/projects/README.md
+++ b/organizations/projects/README.md
@@ -153,10 +153,11 @@ inputs = {
       maintainers = ["Admin1", "Admin2", ...]
     }
     "GhFoundationsDevelopers" = {
-      description = "The development team for ..."
-      privacy     = "closed"
-      members     = ["Member1", "Member2", ...]
-      maintainers = ["Admin1", "Admin2", ...]
+      description     = "The development team for ..."
+      privacy         = "closed"
+      members         = ["Member1", "Member2", ...]
+      maintainers     = ["Admin1", "Admin2", ...]
+      parent_team_id  = <Optional parent team id>
     }
   }
 }


### PR DESCRIPTION
---

### ISSUE

#25: We need to add documentation for the users on how to setup the repositories ad teams. This feature adds the ability to create a README file when the `organizations` repository is created.

---