### PR TITLE
Added a default README to the foundation org

### DIFF
--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -61,6 +61,8 @@ module "foundations_github_organization" {
   gcp_tf_state_bucket_project_id = module.github_gcloud_oidc.project_id
   bucket_name                    = module.github_gcloud_oidc.bucket_name
   bucket_location                = module.github_gcloud_oidc.bucket_location
+
+  readme_path = "../organizations/projects/README.md"
 }
 
 resource "github_enterprise_organization" "organization" {

--- a/organizations/projects/README.md
+++ b/organizations/projects/README.md
@@ -153,10 +153,11 @@ inputs = {
       maintainers = ["Admin1", "Admin2", ...]
     }
     "GhFoundationsDevelopers" = {
-      description = "The development team for ..."
-      privacy     = "closed"
-      members     = ["Member1", "Member2", ...]
-      maintainers = ["Admin1", "Admin2", ...]
+      description     = "The development team for ..."
+      privacy         = "closed"
+      members         = ["Member1", "Member2", ...]
+      maintainers     = ["Admin1", "Admin2", ...]
+      parent_team_id  = <Optional parent team id>
     }
   }
 }


### PR DESCRIPTION
---
### ISSUE

#25: Adds a default README to the Github Foundations organization that is created by the `bootstrap` layer.

Currently, the contents are copied from this repo under the `organizations\projects\README.md file`

---