### PR TITLE
Revert adding a repo README

### DIFF
--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -62,7 +62,6 @@ module "foundations_github_organization" {
   bucket_name                    = module.github_gcloud_oidc.bucket_name
   bucket_location                = module.github_gcloud_oidc.bucket_location
 
-  readme_path = "../organizations/projects/README.md"
 }
 
 resource "github_enterprise_organization" "organization" {


### PR DESCRIPTION
--- 
### ISSUE

#13 - revert changes to add a repo README

We recently attempted to add a method to set contents for a `README.md` file to the organization repo that is created. After testing, and with signed commits and branch protection in place, we don't have the required permissions to alter the contents of the README file.

This change is to revert the addition of the `README.md` file.

---