### PR TITLE
feat: Add delete protection

### DIFF
--- a/organizations/.github/workflows/confirm-deletion.yaml
+++ b/organizations/.github/workflows/confirm-deletion.yaml
@@ -1,0 +1,75 @@
+name: "Confirm Resource Deletion"
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+env:
+  tf_version: 1.7.5
+  tg_version: 0.55.18
+  working_dir: .
+  GCP_SECRET_MANAGER_PROJECT: "${{ vars.GCP_SECRET_MANAGER_PROJECT }}"
+  GCP_TF_STATE_BUCKET_PROJECT: "${{ vars.TF_STATE_BUCKET_PROJECT_ID}}"
+  GCP_TF_STATE_BUCKET_NAME: "${{vars.TF_STATE_BUCKET_NAME}}"
+  GCP_TF_STATE_BUCKET_LOCATION: "${{vars.TF_STATE_BUCKET_LOCATION}}"
+
+jobs:
+    confirm-deletion:
+        permissions:
+            contents: 'read'
+            id-token: 'write'
+            pull-requests: 'write'
+            issues: 'write'
+        name: "Confirm the Deletion"
+        runs-on: ubuntu-latest
+        steps:
+        - name: Confirm Deletion
+          uses: actions/github-script@v7
+          # Run the deletion confirmation, only when a *new*
+          # comment is added to a PR or a review is submitted
+          if: |
+            (github.event.action == 'submitted' &&
+             github.event.review.body == 'delete') ||
+            (github.event.action == 'created' &&
+             github.event.comment.body == 'delete' &&
+             github.event.issue.pull_request)
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            # runs only if there is a 'request changes' review,
+            # created by the Github Actions bot, with a status of
+            # 'outstanding'
+            script: |
+                // First we check if the pull request has a 'request changes' review
+                const reviews = await github.rest.pulls.listReviews({
+                    pull_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo
+                });
+
+                // Filter the reviews to find the one created by the Github Actions bot
+                change_reviews = reviews?.data?.filter(
+                    review => review.state == 'CHANGES_REQUESTED'
+                    && review.user.login?.startsWith('github-actions')
+                );
+
+                console.log(`Found reviews: ${JSON.stringify(change_reviews)}\n\n`);
+
+                if (change_reviews) {
+                    // iterate each pending review and dismiss it
+                    for (const review of change_reviews) {
+                        console.log(`Updating the review with id ${review.id}`)
+                        const result = await github.rest.pulls.dismissReview({
+                            pull_number: context.issue.number,
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            review_id: review.id,
+                            message: 'Deletion confirmed. Ready to merge.'
+                        });
+                        console.log(`Updated the review with id ${review.id}.`)
+
+                    }
+                } else {
+                    console.log('No valid review found');
+                }

--- a/organizations/.github/workflows/drift-detection.yaml
+++ b/organizations/.github/workflows/drift-detection.yaml
@@ -8,8 +8,8 @@ on:
 
 
 env:
-  tf_version: 1.7.1
-  tg_version: 0.55.1
+  tf_version: 1.7.5
+  tg_version: 0.55.18
   default_branch: main
   drift_label: Drift
   action_required_label: Action Required
@@ -63,15 +63,6 @@ jobs:
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
           tg_command: 'hclfmt --terragrunt-check --terragrunt-diff'
-
-      - name: Terragrunt Init
-        id: init
-        uses: gruntwork-io/terragrunt-action@v2
-        with:
-          tf_version: ${{ env.tf_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
-          tg_command: 'run-all init'
 
       - name: Terragrunt Plan
         id: plan
@@ -172,15 +163,6 @@ jobs:
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
           tg_command: 'hclfmt --terragrunt-check --terragrunt-diff'
-
-      - name: Terragrunt Init
-        id: init
-        uses: gruntwork-io/terragrunt-action@v2
-        with:
-          tf_version: ${{ env.tf_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
-          tg_command: 'run-all init'
 
       - name: Terragrunt Apply
         id: apply

--- a/organizations/.github/workflows/on-pull-and-push.yaml
+++ b/organizations/.github/workflows/on-pull-and-push.yaml
@@ -8,8 +8,8 @@ on:
 
 
 env:
-  tf_version: 1.7.1
-  tg_version: 0.55.1
+  tf_version: 1.7.5
+  tg_version: 0.55.18
   working_dir: .
   GCP_SECRET_MANAGER_PROJECT: "${{ vars.GCP_SECRET_MANAGER_PROJECT }}"
   GCP_TF_STATE_BUCKET_PROJECT: "${{ vars.TF_STATE_BUCKET_PROJECT_ID}}"
@@ -58,15 +58,6 @@ jobs:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'hclfmt --terragrunt-check --terragrunt-diff'
 
-      - name: Terragrunt Init
-        id: init
-        uses: gruntwork-io/terragrunt-action@v2
-        with:
-          tf_version: ${{ env.tf_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
-          tg_command: 'run-all init'
-
       - name: Terragrunt Plan
         id: plan
         uses: gruntwork-io/terragrunt-action@v2
@@ -75,7 +66,7 @@ jobs:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
-          tg_command: 'run-all plan --out tfplan'
+          tg_command: 'run-all plan -out tfplan'
 
       - name: Terragrunt Plan Condensing
         id: condense
@@ -85,7 +76,7 @@ jobs:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
-          tg_command: 'run-all show tfplan'
+          tg_command: 'run-all show tfplan --terragrunt-no-color -no-color'
 
       - name: Terragrunt Plan Cleaning
         id: clean
@@ -103,7 +94,6 @@ jobs:
           script: |
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terragrunt Format and Style 🖌\`${{ steps.grunt-fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
 
 
@@ -124,6 +114,48 @@ jobs:
               body: output
             })
 
+      - name: Check/Count Deletions
+        id: deletions
+        if: contains(env.PLAN, 'will be destroyed')
+        continue-on-error: true
+        run: |
+          DELETIONS="$(echo "${{ env.PLAN }}" | grep -c 'will be destroyed')"
+          if [[ $DELETIONS -gt 0 ]]; then
+            echo "DELETIONS=${DELETIONS}" >> $GITHUB_ENV
+            echo "${DELETIONS} Deletion(s) found in the plan."
+          fi
+
+      - name: No Deletions
+        id: no-deletions
+        if: ${{ !contains(env.PLAN , 'will be destroyed') }}
+        # set the env.DELETIONS to 0
+        run: echo "DELETIONS=0" >> $GITHUB_ENV
+
+      - name: Comment on PR if deletions
+        if: env.DELETIONS > 0
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### ⚠️ The Terraform Plan contains ${process.env.DELETIONS} Deletion(s) ⚠️
+            Please review the plan and ensure that the deletions are expected.
+
+            If the deletions are expected, you must:
+
+              1. Create a new comment on this PR.
+              2. Set the contents to \`delete\` (no quotes)
+              3. Press the comment button.
+
+            before you can merge.`;
+
+            github.rest.pulls.createReview({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output,
+              event: 'REQUEST_CHANGES'
+            })
+
       - name: Terraform Plan Status
         if: steps.plan.outcome == 'failure'
         run: exit 1
@@ -135,4 +167,4 @@ jobs:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
-          tg_command: 'run-all apply --terragrunt-no-color '
+          tg_command: 'run-all apply --terragrunt-no-color'


### PR DESCRIPTION
---
### ISSUE

#43 - Feature: Deletion Protection on Pull Requests

As per the client's request, we have added a feature whereby a user is asked to confirm when deletions have been submitted in the PR the user created.

The user will need to review the plan, and confirm that the deletions are intended, by writing a comment (`delete`) on the PR.

---

### TESTING

This was tested by:

- Removing some part of the infrastructure on the `organizations` repo, with the `GitHub Actions Workflows` modified in this PR
- Receiving a review from the `github-actions` bot that changes are requested that contain deletes, with instructions to:
- Reviewed the plan and commented `delete`

I was able to see the PR be:
- Updated with the plan
- Have the actions bot request changes
- Comment on the PR and see the changes removed

I also tested the "normal" path where no changes containing deletes are found, and the process is (correctly) not invoked.

---