### PR TITLE
Drift workflow updates

### DIFF
--- a/organizations/.github/workflows/drift-detection.yaml
+++ b/organizations/.github/workflows/drift-detection.yaml
@@ -110,15 +110,32 @@ jobs:
 
             </details>`;
 
-            const date = new Date();
-
-            github.rest.issues.create({
+            const issues = (await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Drift Detected ${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
-              body: output,
-              labels: [drift_label, action_required_label]
-            })
+              labels: drift_label,
+              sort: 'created',
+              direction: 'desc',
+              per_page: 1
+            })).data;
+
+            if (issues.length == 0) {
+              github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Drift Detected',
+                body: output,
+                labels: [drift_label, action_required_label]
+              });
+            }else {
+              github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues[0].number,
+                body: output,
+                labels: [drift_label, action_required_label]
+              });
+            }
 
   re-run-apply:
     permissions:
@@ -126,7 +143,7 @@ jobs:
       id-token: 'write'
       pull-requests: 'write'
       issues: 'write'
-    name: "Run Drift Detection"
+    name: "Run Apply"
     if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'Re-Apply'
     runs-on: ubuntu-latest
     defaults:

--- a/organizations/DRIFT_DETECTION.md
+++ b/organizations/DRIFT_DETECTION.md
@@ -48,7 +48,7 @@ The `Drift Detection` jobs are scheduled to run automatically based on the cron 
 
 When a drift is detected during the scheduled check and no other open issues exist with the `Drift` label, the action will create a GitHub issue in your repository. The issue will contain detailed information about the detected drift and steps for review. The issue will be labeled with `Drift` and `Action Required` labels for easy identification and filtering.
 
-If a drift is detected and an open issue already exist with the `Drift` label, the action will update the Github issue's body with the newly detected changes in the Github infrastructure. This ensures only a single drift detection issue will be opened at a time and avoids a scenario where the repositories issue list is flooded with redundant drift detection issues.
+If a drift is detected and an open issue already exists with the `Drift` label, the action will update the GitHub issue's body with the newly detected changes in the GitHub infrastructure. This ensures only a single drift detection issue will be opened at a time and avoids a scenario where the repository's issue list is flooded with redundant drift detection issues.
 
 ### Manual Re-Apply
 

--- a/organizations/DRIFT_DETECTION.md
+++ b/organizations/DRIFT_DETECTION.md
@@ -46,7 +46,9 @@ The `Drift Detection` jobs are scheduled to run automatically based on the cron 
 
 ### Issue Creation
 
-When a drift is detected during the scheduled check, the action will create a GitHub issue in your repository. The issue will contain detailed information about the detected drift and steps for review. The issue will be labeled with `Drift` and `Action Required` labels for easy identification and filtering.
+When a drift is detected during the scheduled check and no other open issues exist with the `Drift` label, the action will create a GitHub issue in your repository. The issue will contain detailed information about the detected drift and steps for review. The issue will be labeled with `Drift` and `Action Required` labels for easy identification and filtering.
+
+If a drift is detected and an open issue already exist with the `Drift` label, the action will update the Github issue's body with the newly detected changes in the Github infrastructure. This ensures only a single drift detection issue will be opened at a time and avoids a scenario where the repositories issue list is flooded with redundant drift detection issues.
 
 ### Manual Re-Apply
 


### PR DESCRIPTION
Updates drift detection workflow so it only creates an issue when there is no other issue with the Drift label. If there is then it updates the issue's body with the newly detected change information

Updates documentation to include this explanation.