### PR TITLE
Fix-pull-and-push-plan-failure-cleanup

### DIFF
--- a/organizations/.github/actions/find-tf-lockfiles/action.yaml
+++ b/organizations/.github/actions/find-tf-lockfiles/action.yaml
@@ -1,0 +1,121 @@
+name: Clean TF lock files
+description: 'Clean stale Terraform lock files'
+inputs:
+  terragrunt_output:
+    description: 'The output of the Terragrunt plan command, containing a lock error.'
+    required: true
+  tf_state_path:
+    description: 'The base path to the Terraform state files. Will be used to determine the relative paths of state locks'
+    required: true
+outputs:
+  stale_lock_files:
+    description: 'A list of stale lock files that were removed.'
+    value: ${{ steps.find-stale-locks.outputs.stale_lock_files }}
+
+runs:
+  using: 'composite'
+  steps:
+      - name: Collect lock file metadata on error
+        shell: bash
+        id: collect-lock-files
+        run: |
+          tg_action_output=$(cat<<EOF
+          ${{ inputs.terragrunt_output }}
+          EOF
+          )
+
+          lock_info_blocks=$(echo -e "$tg_action_output" | grep -Pzo "Lock Info:.*?Info:\s*" | tr -dc '[:print:]' | sed 's/%0A/\n/g' )
+
+          IFS=$'\n\n'  # Set internal field separator to two newlines
+          declare -A lock_info_array
+
+          index=-1
+          while read -r line; do
+
+            lock_info=""
+
+            # Check if line starts with "Lock Info:"
+            if [[ $line =~ .*ID:.* ]]; then
+              index=$(($index + 1))
+              # Extract key-value pairs and store in array
+              id_value=$(echo "${line#*:}" | tr -d '[:space:]')  # Remove leading/trailing whitespace for value
+              id_info="{\"id\":\"$id_value\"}"
+
+            elif
+              # get the path
+              [[ $line =~ .*Path:.* ]]; then
+                path=$(echo "${line#*:}")
+
+                # Clean the spaces at the beginning of the value
+                path_value=$(echo $path | sed 's/^[ \t]*//')
+
+                # remove the base path from the path
+                path_value=$(echo $path_value | sed "s|${{ inputs.tf_state_path }}||")
+
+                # remove the trailing "default.tflock" from the path
+                path_value=$(echo $path_value | sed 's/default.tflock//')
+
+                # remove the last character, and append
+                first_part=${id_info%?}
+                id_info="$first_part,\"path\":\"$path_value\"}"
+            elif
+              # get the created time
+              [[ $line =~ .*Created:.* ]]; then
+                created=$(echo "${line#*:}")
+
+                # Clean the spaces at the beginning of the value
+                created_value=$(echo $created | sed 's/^[ \t]*//')
+                created_value=$(echo $created_value | sed 's/ /T/')  # Replace first space with T
+                created_value=$(echo $created_value | sed 's/\+0000 UTC/+00:00/')  # Replace " +0000 UTC" with "+00:00"
+
+                # remove the last character, and append
+                first_part=${id_info%?}
+                lock_info="$first_part,\"created\":\"$created_value\"}"
+
+                echo -e "Found lock $index: $lock_info"
+            fi
+
+            # Append lock info to array
+            if [[ -n $lock_info ]]; then
+              lock_info_array[$index]=$lock_info
+            fi
+
+          done < <(echo -e "$lock_info_blocks")
+          # done
+
+          unset IFS  # Reset IFS to default behavior
+
+          # Set the array as an output
+          echo "lock_files=$(IFS=','; echo "[${lock_info_array[*]}")]" >> $GITHUB_OUTPUT
+
+      - name: Find stale locks
+        shell: bash
+        id: find-stale-locks
+        if: steps.collect-lock-files.outputs.lock_files != ''
+        run: |
+          lock_files=$(echo -e '${{ steps.collect-lock-files.outputs.lock_files }}')
+
+          locks=""
+          while read -r lock_file; do
+
+            # use JQ to get the Created field
+            lock_created=$(jq -r '.created' <<< $lock_file)
+
+            if [ -n "$lock_created" ]; then
+
+              lock_created_epoch=$(date -d "$lock_created" +%s)
+              current_epoch=$(date +%s)
+              age=$((current_epoch - lock_created_epoch))
+              echo "Lock created $lock_created is $age seconds old."
+
+            # If the lock is older than 1 hour, list it
+              if [ $age -gt 3600 ]; then
+                # Add the entry to the stale lock files array
+                locks=$(echo "$locks,$lock_file")
+              fi
+            fi
+          done < <(echo "$lock_files" | jq -c '.[]')
+
+          stale_lock_files="[${locks#,}]"
+          # Set the array as an output
+          echo "stale_lock_files=${stale_lock_files}" >> $GITHUB_OUTPUT

--- a/organizations/.github/workflows/on-pull-and-push.yaml
+++ b/organizations/.github/workflows/on-pull-and-push.yaml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Find stale Terraform lock files
         id: find-stale-lock-files
-        uses: FociSolutions/github-foundations/organizations/.github/actions/find-tf-lockfiles@fix-pull-and-push-plan-fail-cleanup
+        uses: FociSolutions/github-foundations/organizations/.github/actions/find-tf-lockfiles@main
         if: failure()
         with:
           terragrunt_output: ${{ steps.plan.outputs.tg_action_output }}

--- a/organizations/.github/workflows/on-pull-and-push.yaml
+++ b/organizations/.github/workflows/on-pull-and-push.yaml
@@ -25,6 +25,11 @@ jobs:
       issues: 'write'
     name: "Terraform Plan and Apply"
     runs-on: ubuntu-latest
+    concurrency:
+      group: terraform-plan-and-apply
+      cancel-in-progress: false
+    outputs:
+      lock_files: ${{ steps.find-stale-lock-files.outputs.stale_lock_files }}
     defaults:
       run:
         shell: bash
@@ -41,6 +46,7 @@ jobs:
       - name: GCP Auth
         id: auth
         uses: google-github-actions/auth@v2
+
         with:
           workload_identity_provider: "${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}"
           service_account: "${{ secrets.GCP_SERVICE_ACCOUNT }}"
@@ -68,8 +74,17 @@ jobs:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'run-all plan -out tfplan'
 
+      - name: Check if there are any changes
+        id: changes
+        run: |
+          if [ -f tfplan ]; then
+            PLAN=$(cat tfplan)
+            echo "plan_size=$(echo "${PLAN}" | grep -c) " >> $GITHUB_OUTPUT
+          fi
+
       - name: Terragrunt Plan Condensing
         id: condense
+        if: steps.changes.outputs.plan_size > 0
         uses: gruntwork-io/terragrunt-action@v2
         continue-on-error: true
         with:
@@ -80,15 +95,16 @@ jobs:
 
       - name: Terragrunt Plan Cleaning
         id: clean
+        if: steps.changes.outputs.plan_size > 0
         run: |
           TG_OUT=$(echo "${{ steps.condense.outputs.tg_action_output }}" | sed 's|%0A|\n|g')
-          echo "PLAN<<EOF" >> $GITHUB_ENV
-          echo "$TG_OUT" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "condensed_plan<<EOF" >> $GITHUB_OUTPUT
+          echo "$TG_OUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Update Pull Request
         uses: actions/github-script@v7
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.plan_size > 0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -100,7 +116,7 @@ jobs:
             <details><summary>Show Plan</summary>
 
             \`\`\`\n
-            ${process.env.PLAN}
+            ${{ steps.clean.outputs.condensed_plan }}
             \`\`\`
 
             </details>
@@ -116,7 +132,7 @@ jobs:
 
       - name: Check/Count Deletions
         id: deletions
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.plan_size > 0
         continue-on-error: true
         run: |
           DELETIONS="$(echo "${{ env.PLAN }}" | grep -c 'will be destroyed')"
@@ -153,10 +169,59 @@ jobs:
         run: exit 1
 
       - name: Terragrunt Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.changes.outputs.plan_size > 0
         uses: gruntwork-io/terragrunt-action@v2
         with:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
           tg_dir: ${{ env.working_dir }}
           tg_command: 'run-all apply --terragrunt-no-color'
+
+      - name: Find stale Terraform lock files
+        id: find-stale-lock-files
+        uses: FociSolutions/github-foundations/organizations/.github/actions/find-tf-lockfiles@fix-pull-and-push-plan-fail-cleanup
+        if: failure()
+        with:
+          terragrunt_output: ${{ steps.plan.outputs.tg_action_output }}
+          tf_state_path: "gs://${{ vars.TF_STATE_BUCKET_NAME }}/terraform/github-foundations/organizations/"
+
+  clean-stale-locks:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      pull-requests: 'write'
+      issues: 'write'
+    name: "Clean Stale Locks"
+    runs-on: ubuntu-latest
+    concurrency:
+      group: terraform-plan-and-apply
+      cancel-in-progress: false
+    needs: terraform-plan-and-apply
+    if: failure() && needs.terraform-plan-and-apply.outputs.lock_files
+    strategy:
+      fail-fast: false
+      matrix:
+        lock_file_info: ${{ fromJson(needs.terraform-plan-and-apply.outputs.lock_files).* }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.tf_version }}
+
+      - name: GCP Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}"
+          service_account: "${{ secrets.GCP_SERVICE_ACCOUNT }}"
+
+      - name: Clean stale locks
+        uses: gruntwork-io/terragrunt-action@v2
+        with:
+          tf_version: ${{ env.tf_version }}
+          tg_version: ${{ env.tg_version }}
+          tg_dir: ${{ matrix.lock_file_info.path }}
+          tg_command: "force-unlock -force ${{ matrix.lock_file_info.id }}"


### PR DESCRIPTION
### ISSUE

[#66] - [Bug] on-push-and-pull action fails when there are not Terraform changes

This change:

- Adds an action that will find stale lock files (older than 1 hour)
- Adds a step that runs on failure, uses the action above to check for any stale lock files, and cleans them up
- Uses `concurrency` to lock action steps from running at the same time, causing locking issues

---