### PR TITLE
76-docs-incorporate-tbs-feedback-into-guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ Managing GitHub for large enterprises introduces complex security and consistenc
 
 ### Project Features:
 
-- **Automate Continuous Secure Infrastructure:** 
-  - Use Terraform to apply Infrastructure as Code (IaC) principles in managing multiple organizations under a single GitHub Enterprise account. 
+- **Automate Continuous Secure Infrastructure:**
+  - Use Terraform to apply Infrastructure as Code (IaC) principles in managing multiple organizations under a single GitHub Enterprise account.
   - Establish and enforce security best practices by default.
   - Use drift detection to promptly identify and rectify unauthorized changes, ensuring your configurations are always secure.
 
-- **Centralize Control:** 
+- **Centralize Control:**
   - Gain a comprehensive overview for managing organizations, repositories, and teams across your enterprise.
-  - Streamline updates and security policy enforcement across your entire enterprise, reducing the need for manual intervention. 
+  - Streamline updates and security policy enforcement across your entire enterprise, reducing the need for manual intervention.
 
-- **Rapid Rollouts:** 
+- **Rapid Rollouts:**
   - Push policy updates across the entire enterprise in moments rather than waiting days for each organization to schedule individual exercises.
   - Automate repetitive tasks, allowing teams to focus on innovation.
 
-- **Reduce Security Risks:** 
+- **Reduce Security Risks:**
   - Enforce consistent security policies across all organizations to minimize vulnerabilities and protect against attacks.
   - Have a unified view of potential vulnerabilities to prevent gaps opening in one organization or another.
 

--- a/guardrails/09_Plan-for-Continuity.md
+++ b/guardrails/09_Plan-for-Continuity.md
@@ -1,0 +1,33 @@
+# Plan for Continuity
+
+([Back](../../GUARDRAILS.md))
+
+## Objective
+
+Ensure that there is a plan for continuity of access and service that accommodates both expected and unexpected events.
+This section contains the Guardrails that address controls in the following contexts:
+
+- Access Control (AC)
+- Security Assessment and Authorization (CA)
+- Contingency Planning (CP)
+
+## Conditional Requirements
+
+### Self-hosting considerations
+
+| Activity | Validation |
+| --- | --- |
+| Document, implement, and test a break glass emergency account management process. | <ul> <li>Verify that an emergency account management procedure has been developed</li><li>Verify that alerts are in place to report any use of emergency accounts</li> <li>Verify that testing of emergency accounts took place, and that periodic testing is included in emergency account management procedures.</li> </ul> |
+| Obtain confirmation from the departmental chief information officer (CIO) in collaboration with the designated official for cyber security (DOCS) with signatures that acknowledge and approve the emergency account management procedures. | <ul><li>Confirm through attestation that the departmental CIO, in collaboration with the DOCS, has approved the emergency account management procedure for the SCM service.</li> </ul> |
+| Develop an SCM backup strategy that considers where GC data is stored, replicated, or backed up by the SCM service, and the IT continuity plan for the service or application. | <ul><li>Confirm through attestation that the SCM backup strategy is developed and approved by the business owner.</li><li>Verify if there are scripts that support the ability to restore from code (for example, infrastructure as code).</li></ul> |
+
+## References
+
+- [Direction on the Secure Use of Commercial Cloud Services: Security Policy Implementation Notice](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/security-identity-management/direction-secure-use-commercial-cloud-services-spin.html) (SPIN) 2017-01, subsection 6.2.9
+- [Break glass emergency account management procedure](https://gcconnex.gc.ca/file/view/55010566/break-glass-emergency-account-procedure-departments-can-use-to-develop-their-emergency-access-management-controls-for-cloud?language=en) for Azure and Office 365 (accessible only on the Government of Canada network)
+- [Cyber Security Event Management Plan template](https://www.gcpedia.gc.ca/gcwiki/images/6/66/Department_CSEMP_Template.docx) for departments (Word file) (accessible only on the Government of Canada network)
+- [Directive on Service and Digital](https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=32601)
+
+## Related security controls from ITSG-33
+
+AC-1, CA-3, CP-1, CP-2, CP-9

--- a/guardrails/09_Plan-for-Continuity.md
+++ b/guardrails/09_Plan-for-Continuity.md
@@ -13,13 +13,16 @@ This section contains the Guardrails that address controls in the following cont
 
 ## Conditional Requirements
 
+| Activity | Validation |
+| --- | --- |
+| Develop an SCM backup strategy that considers where GC data is stored, replicated, or backed up by the SCM service, and the IT continuity plan for the service or application. | <ul><li>Confirm through attestation that the SCM backup strategy is developed and approved by the business owner.</li><li>Verify if there are scripts that support the ability to restore from code (for example, infrastructure as code).</li></ul> |
+
 ### Self-hosting considerations
 
 | Activity | Validation |
 | --- | --- |
 | Document, implement, and test a break glass emergency account management process. | <ul> <li>Verify that an emergency account management procedure has been developed</li><li>Verify that alerts are in place to report any use of emergency accounts</li> <li>Verify that testing of emergency accounts took place, and that periodic testing is included in emergency account management procedures.</li> </ul> |
 | Obtain confirmation from the departmental chief information officer (CIO) in collaboration with the designated official for cyber security (DOCS) with signatures that acknowledge and approve the emergency account management procedures. | <ul><li>Confirm through attestation that the departmental CIO, in collaboration with the DOCS, has approved the emergency account management procedure for the SCM service.</li> </ul> |
-| Develop an SCM backup strategy that considers where GC data is stored, replicated, or backed up by the SCM service, and the IT continuity plan for the service or application. | <ul><li>Confirm through attestation that the SCM backup strategy is developed and approved by the business owner.</li><li>Verify if there are scripts that support the ability to restore from code (for example, infrastructure as code).</li></ul> |
 
 ## References
 

--- a/guardrails/EN/01_Protect-user-accounts-and-identities.md
+++ b/guardrails/EN/01_Protect-user-accounts-and-identities.md
@@ -43,4 +43,4 @@ This section contains the Guardrails that address controls in the following area
 
 ## Related security controls from ITSG-33
 
-AC-2, AC-2(11), AC-3, AC-5, AC-6, AC-6(5), AC-6(10), AC-7, AC-19, AC-20(3), IA-2, IA-2(1), IA-2(2), IA-2(3), IA-2(11), IA-5(1), IA-5(8), SI-4, SI-4(5), SA-4(12), CM-5
+AC-2, AC-2(3), AC-2(11), AC-3, AC-5, AC-6, AC-6(5), AC-6(10), AC-7, AC-19, AC-20(3), IA-2, IA-2(1), IA-2(2), IA-2(3), IA-2(11), IA-5(1), IA-5(8), SI-4, SI-4(5), SA-4(12), CM-5

--- a/guardrails/EN/02_Manage-Role-Access.md
+++ b/guardrails/EN/02_Manage-Role-Access.md
@@ -43,4 +43,4 @@ This section contains the Guardrails that address controls in the following area
 
 ## Related security controls from ITSG-33
 
-AC‑2, AC‑2(1), AC‑2(7) AC‑3, AC‑3(7), AC‑3, AC‑4 AC‑5, AC‑6, AC‑6(5), IA‑2, IA‑2(1), IA‑2(8), IA‑2(11), IA‑4, IA‑5, IA‑5(1), IA‑5(6)
+AC‑2, AC‑2(1), AC‑2(7) AC‑3, AC‑3(7), AC‑3, AC‑4 AC‑5, AC‑6, AC‑6(5), AC-16(2),IA‑2, IA‑2(1), IA‑2(8), IA‑2(11), IA‑4, IA‑5, IA‑5(1), IA‑5(6), IA-8, IA-8(100)

--- a/guardrails/EN/03_Secure-Endpoints.md
+++ b/guardrails/EN/03_Secure-Endpoints.md
@@ -41,7 +41,7 @@ This section contains the Guardrails that address controls in the following area
 - [Directive on Service and Digital, Appendix G: Standard on Enterprise Information Technology Service Common Configurations](https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=32713)
 - [Endpoint Management Configuration Requirements](https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/endpoint.html)
 - [Guidance on Defence in Depth for Cloud-Based Services (ITSP.50.104)](https://cyber.gc.ca/en/guidance/itsp50104-guidance-defence-depth-cloud-based-services), subsection 4.9
-- [User Authenticaion Guidance for Information Technology Systems (ITSP.30.031 v3)](https://cyber.gc.ca/en/guidance/user-authentication-guidance-information-technology-systems-itsp30031-v3)
+- [User Authentication Guidance for Information Technology Systems (ITSP.30.031 v3)](https://cyber.gc.ca/en/guidance/user-authentication-guidance-information-technology-systems-itsp30031-v3)
 - [Cryptographic algorithms for UNCLASSIFIED, PROTECTED A, and PROTECTED B information (ITSP.40.111)](https://www.cyber.gc.ca/en/guidance/cryptographic-algorithms-unclassified-protected-protected-b-information-itsp40111)
 
 ## Related security controls from ITSG-33

--- a/guardrails/EN/03_Secure-Endpoints.md
+++ b/guardrails/EN/03_Secure-Endpoints.md
@@ -46,4 +46,4 @@ This section contains the Guardrails that address controls in the following area
 
 ## Related security controls from ITSG-33
 
-AC3, AC-3(7), AC-4, AC-5, AC-6, AC6(5), AC-6(10), AC-19, AC-20(3), IA-2, IA-2(1), IA-2(11), IA-4, IA-5, IA-5(1), SI-4, AU-6, AU-12
+AC3, AC-3(7), AC-4, AC-5, AC-6, AC6(5), AC-6(10), AC-17(1), AC-17(2), AC-19, AC-20(3), AU-6, AU-12, IA-2, IA-2(1), IA-2(11), IA-4, IA-5, IA-5(1), SC-8, SC-8(1), SI-4

--- a/guardrails/EN/04_Enterprise-Monitoring-Accounts.md
+++ b/guardrails/EN/04_Enterprise-Monitoring-Accounts.md
@@ -5,7 +5,7 @@
 
 ## Objective
 
-Create role-based account to enable enterprise monitoring and visibility.  
+Create role-based account to enable enterprise monitoring and visibility.
 This section contains the Guardrails that address controls in the following contexts:
 
 - Access Control (AC)
@@ -18,7 +18,7 @@ This section contains the Guardrails that address controls in the following cont
 | Activity  | Validation |
 | --- | --- |
 | Create role-based accounts to enable enterprise monitoring and visibility for cloud environments that are procured via the GC Cloud Broker or are included in the scope of centralized guardrails validation. | <ul><li>Verify that roles required to enable visibility in the GC have been provisioned or assigned.</li></ul> |
-| Maintain healthy management of associated rols. | <ul><li>Verify the implementation of controls listed under [Manage Role Access](./02_Manage-Role-Access.md)</li></ul> |
+| Maintain healthy management of associated roles. | <ul><li>Verify the implementation of controls listed under [Manage Role Access](./02_Manage-Role-Access.md)</li></ul> |
 | Have a plan in place for responding to security incidents detected through monitoring, including roles and responsibilities, communication plans, and recovery procedures. | <ul><li>Provide evidence that a plan is in place for responding to security incidents detected through monitoring, including roles and responsibilities, communication plans, and recovery procedures.</li></ul> |
 
 ## Conditional Requirements
@@ -32,8 +32,8 @@ This section contains the Guardrails that address controls in the following cont
 
 - [Direction on the Secure Use of Commercial Cloud Services: Security Policy Implementation Notice](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/security-identity-management/direction-secure-use-commercial-cloud-services-spin.html) (SPIN) 2017-01, subsection 6.2.3
 - Cyber Centre’s top 10 IT security actions, number 2
-- [IT Security Risk Management: A Lifecycle Approach (ITSG-33), Annex 3A: Security Control Catalogue](https://cyber.gc.ca/en/guidance/it-security-risk-management-lifecycle-approach-itsg-33), AC-3(7)
+- [IT Security Risk Management: A Lifecycle Approach (ITSG-33), Annex 3A: Security Control Catalogue](https://cyber.gc.ca/en/guidance/it-security-risk-management-lifecycle-approach-itsg-33)
 
 ## Related security controls from ITSG-33
 
-AC-2, AC-3(7), AC-6(5), AU-2, AU-6, IA-2(1)
+AC-2, AC-2(4), AC-3(7), AC-6(5), AC-6(9), AU-2, AU-6, IA-2(1), SI-4(7), SI-10

--- a/guardrails/EN/05_Data-Protection.md
+++ b/guardrails/EN/05_Data-Protection.md
@@ -20,7 +20,8 @@ This section contains the Guardrails that address controls in the following cont
 | Activity | Validation |
 | --- | --- |
 | Implement an encryption mechanism to protect the confidentiality and integrity of data when data is at rest in storage.| <ul><li>For SaaS, confirm that the SCM platform has implemented encryption to protect customer data.</li></ul> |
-| Use cryptographic algorithms and protocols approved by Communications Security Establishment Canada (CSE) in accordance with ITSP.40.111 and ITSP.40.062.| <ul><li>Cryptographic algorithms and protocols configurable by the consumer are in accordance with ITSP.40.111 and ITSP.40.062.</li><li>For SaaS, confirm that the CSP has implemented algorithms that align with ITSP.40.111 and ITSP.40.062.</li></ul>  |
+| Use cryptographic algorithms and protocols approved by Communications Security Establishment Canada (CSE) in accordance with ITSP.40.111 and ITSP.40.062.| <ul><li>Cryptographic algorithms and protocols configurable by the consumer are in accordance with ITSP.40.111 and ITSP.40.062.</li><li>For SaaS, confirm that the CSP has implemented algorithms that align with ITSP.40.111 and ITSP.40.062.</li></ul>|
+| Enforce the use of _Pull Request_ (PR) reviews, and _Protected Branches_ to ensure that code changes are reviewed and approved by at least one other developer before being merged into the main branch.| <ul><li>Confirm that PR reviews are enforced for all code changes being merged into the default branch of the repository (often called _main_, or _develop_).</li></ul> |
 
 ## Conditional Requirements
 
@@ -50,4 +51,4 @@ This section contains the Guardrails that address controls in the following cont
 
 ## Related security controls from ITSG-33
 
-SC12, SC13, SC-17, SC28, SC28(1)
+SC-12, SC-13, SC-17, SC-28, SC-28(1)

--- a/guardrails/EN/07_Cyber-Defense-Services.md
+++ b/guardrails/EN/07_Cyber-Defense-Services.md
@@ -16,7 +16,7 @@ This section contains the Guardrails that address controls in the following cont
 | Activity | Validation |
 | --- | --- |
 | Use threat-detection services that monitor for and alert on suspicious activity, such as multiple failed login attempts, unusual data access patterns, or known malicious IP addresses. | <ul><li>Ensure, at a minimum, that the activity is logged and sent to a SIEM (Security Information and Event Management) tool for analysis.</li></ul> |
-| Ensure all changes to the SCM configuration are reviewed and approved by an authorized individual. | <ul><li>Use Pull Requests or Merge Requests to review and approve changes to the SCM configuration.</li></ul> |
+| Ensure all changes to the SCM configuration are reviewed and approved by an authorized individual. | <ul><li>Use documented processes to review and approve changes to the SCM configuration</li><li>When using configuration-as-code, Use Pull Requests or Merge Requests to review and approve changes to the SCM configuration.</li></ul> |
 
 
 ## Conditional Requirements


### PR DESCRIPTION
### ISSUE

Upon request, the TBS client provided the following feedback regarding the current Guardrails:

> “Use Pull Requests or Merge Requests to review and approve changes to the SCM configuration.”

> Which assumes you have an Infra as code approach to the management of your SCM. I would recommend changing that to something like “use documented processes to review and approve changes to the SCM configuration” because you will still have folks who clickops things.

> Also there might be a place for [Plan for Continuity - Canada.ca](https://github.com/canada-ca/cloud-guardrails/blob/master/EN/13_Plan-for-Continuity.md) especially for SaaS SCM’s you should have a third party back up solution in place (ex. daily S3 backups)

---

Additionally, some ITSG Control coverage is missing from the Guardrails docs for the controls:

```
AC-2(3), AC-2(4), AC-6(9), AC-8, AC-9, AC-9(3), AC-12, AC-16(2), AC-17(1), AC-17(2), AC-17(100), 
IA-2(11), IA-5(6), IA-5(7), IA-8, IA-8(100), IA-9, IA-9(1), IA-9(2), 
SC-8, SC-8(1), 
SI-10, SI-12, SI-4(5), SI-4(7)
```

---

After incorporating the above controls into the docs, the following will not be implemented / need to be added to the Risk register:

```
- AC-8, AC-9, AC-9(3), AC-12,
- AC-17(100),
- IA-9, IA-9(1), IA-9(2),
- SI-12
``` 
---