### PR TITLE
fix: python script is returning wrong org name

### DIFF
--- a/organizations/.github/scripts/gh_foundations/gh_foundations.py
+++ b/organizations/.github/scripts/gh_foundations/gh_foundations.py
@@ -58,7 +58,7 @@ def find_terragrunt_hcl_files(root_dir=projects_dir)->list:
     return hcl_files
 
 
-def find_orgs_from_filenames(hcl_files, index_of_key=5)->dict:
+def find_orgs_from_filenames(hcl_files, index_of_key=-3)->dict:
     """ Find all orgs given a set of terragrunt.hcl file paths
 
     Args:


### PR DESCRIPTION
### ISSUE

[#82]

After committing the latest changes to the GH Actions python script, the `GitHub Advanced Security (GHAS)` [checks are failing](https://github.com/foci-github-foundations/organizations/actions/runs/8933181275/job/24538167565#logs).

It appears that it is parsing the wrong part of the path to determine the Organization's name

---