### PR TITLE
Update setup docs, adding azure setup doc instructions

### DIFF
--- a/bootstrap/AZURE_SETUP.md
+++ b/bootstrap/AZURE_SETUP.md
@@ -1,0 +1,34 @@
+# Preparing Azure for Github Foundations
+
+This document will walk you through what is required of your Azure (Az) setup to run the Github Foundations bootstrap layer.
+
+## Setup
+
+**1. Install Azure CLI tool**
+* Install the Azure CLI tool according to your operating system's instructions ([https://learn.microsoft.com/en-us/cli/azure/install-azure-cli](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli))
+
+**2. Setup an Azure Key Vault (optional)**
+* Create an Azure Key Vault to store secrets that will be required by the Github Foundations organization layer to authenticate with Github. If you wish to bring your own secret manager you can skip this step.
+* **Note: If you do bring a different solution to the toolkit ensure that it's secrets can either be accessed via Terraform or added to the environment of the github action runner so it can be read by Terraform**
+
+**3. Authenticate with required permissions**
+* At minimum your account will need the following roles scoped to the subscription or resource group that the Azure resources should be created in:
+    * `Reader`
+    * `Storage Account Contributor`
+    * `Storage Blob Data Contributor`
+    * `Managed Identity Contributor`
+    * `Role Based Access Control Administrator`
+* Additionally you will need the following roles if:
+    * You want Github Foundations to create a new Resource Group for it's Azure resources:
+        * `Contributor` or `Owner` scoped to the subscription the resource group will be created in.
+        * **Note The previously listed roles should be scoped to the subscription since the resource group won't exist yet**
+    * If you are using an Azure Key Vault to store secrets needed to authenticate with Github:
+        * `Key Vault Reader` scoped to the resource group that the Azure Key Vault exists under.
+        * `Role Based Access Control Administrator` scoped to the Azure Key Vault you want to use.
+* Once you have confirmed your account has the required permissions authenticate using the Azure CLI: `az login`
+
+**Resources:**
+
+* Azure CLI: [https://learn.microsoft.com/en-us/cli/azure/install-azure-cli](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+* Azure Role-Based Access Control Built-in Roles: [https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)
+* Azure CLI Role Assignment: [https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli)

--- a/bootstrap/CUSTOM_CLOUD_SETUP.md
+++ b/bootstrap/CUSTOM_CLOUD_SETUP.md
@@ -2,6 +2,7 @@
 
 Currently Github Foundations supports using the following cloud providers:
 - Google Cloud Platform (GCP)
+- Microsoft Azure (Az)
 
 However it is possible to use other cloud providers to store Terraform state files remotely, the setup process is just a little different and requires some file modifications.
 

--- a/bootstrap/GCP_SETUP.md
+++ b/bootstrap/GCP_SETUP.md
@@ -1,0 +1,25 @@
+# Preparing Google Cloud Platform for Github Foundations
+
+This document will walk you through what is required of your Google Cloud Platform (GCP) setup to run the Github Foundations bootstrap layer.
+
+## Setup
+
+**1. Install Gcloud CLI tool**
+* Install the Google Cloud Platform tool according to your operating system's instructions ([https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install))
+
+**2. Authenticate with required permissions**
+* Login to the GCP CLI with the command `gcloud auth application-default login` under a service account with the following roles for your organization:
+    * `roles/iam.workloadIdentityPoolAdmin`
+    * `roles/iam.serviceAccountAdmin`
+    * `roles/resourcemanager.projectMover`
+    * `roles/resourcemanager.projectDeleter`
+    * `roles/resourcemanager.folderEditor`
+    * `roles/storage.admin`
+    * `roles/storage.objectAdmin`
+
+**Note:** This setup will grant extensive permissions within your GCP project and organization. Please ensure you understand the implications of assigning these roles and permissions before proceeding.
+
+**Resources:**
+
+* GCP CLI: [https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install)
+* GCP IAM Roles: [https://cloud.google.com/iam/docs/understanding-roles](https://cloud.google.com/iam/docs/understanding-roles)

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -24,29 +24,16 @@ Before running the bootstrap layer, please ensure you have the following prerequ
   * Choose your preferred protocol for Git operations.
   * Choose a method to authenticate with GitHub, when prompted.
 
-**2. Google Cloud Platform (GCP) CLI:**
+**2. Prepare your cloud environment:**
 
-* Install the GCP CLI according to your operating system's instructions ([https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install)).
-* Authenticate to your GCP instance with the following command `gcloud auth application-default login`.
-
-**3. GCP Service Account and Permissions:**
-
-* Login to the GCP CLI with the command `gcloud auth application-default login` under a service account with the following roles for your organization:
-    * `roles/iam.workloadIdentityPoolAdmin`
-    * `roles/iam.serviceAccountAdmin`
-    * `roles/resourcemanager.projectMover`
-    * `roles/resourcemanager.projectDeleter`
-    * `roles/resourcemanager.folderEditor`
-    * `roles/storage.admin`
-    * `roles/storage.objectAdmin`
-
-**Note:** These prerequisites grant extensive permissions within your GCP project and organization. Please ensure you understand the implications of assigning these roles and permissions before proceeding.
+* Github Foundations currently provides modules to setup OIDC for the following cloud providers:
+    * [Azure](./AZURE_SETUP.md)
+    * [Google Cloud Platform](./GCP_SETUP.md)
+* If you want to use Github Foundations with a different cloud provider refer to the section [below](Running the Bootstrap Layer With An Unsupported Cloud Provider).
 
 **Resources:**
 
 * GitHub CLI: [https://cli.github.com/](https://cli.github.com/)
-* GCP CLI: [https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install)
-* GCP IAM Roles: [https://cloud.google.com/iam/docs/understanding-roles](https://cloud.google.com/iam/docs/understanding-roles)
 
 ## Single Organization Setup Vs Multi-Organization Setup
 


### PR DESCRIPTION
Adds setup documentation in the bootstrap layer for azure integration.

Docs describing changes needed for workflow files will be out in a different PR due to it being more work than just updating some docs. Workflow files will likely need to be changed to dry and generalize a bit more to make it easier to add other cloud providers