### PR TITLE
fix: made bucket name a var. Update docs

### DIFF
--- a/bootstrap/.trivyignore
+++ b/bootstrap/.trivyignore
@@ -1,0 +1,2 @@
+# Ignore a warning about customer encryption on buckets
+AVD-GCP-0066

--- a/bootstrap/backend.tf
+++ b/bootstrap/backend.tf
@@ -14,10 +14,27 @@
  * limitations under the License.
  */
 
-# After the first successful "terraform apply" uncomment this block and run "terraform init"
+# After the first successful "terraform apply":
+#
+# - uncomment this block
+# - replace the bucket name with the one you set, or the default: github-foundations-tf-state-{{ you_org_id }}
+# - (Optional) If using Azure: Replace the Storage Account name
+# - run "terraform init"
+
+### GCP ###
 # terraform {
 #   backend "gcs" {
-#     bucket = "github-tf-state-bucket"
+#     bucket = "github-foundations-tf-state-1234567890"
 #     prefix = "terraform/github-foundations/bootstrap"
 #   }
+# }
+
+### AZURE ###
+# terraform {
+#  backend "azurerm" {
+#    resource_group_name  = "StorageAccount-ResourceGroup"
+#    storage_account_name = "replace-me-with-your-storage-account-name"
+#    container_name       = "github-foundations-tf-state-1234567890"
+#    key                  = "prod.terraform.tfstate"
+#  }
 # }

--- a/bootstrap/backend.tf
+++ b/bootstrap/backend.tf
@@ -17,14 +17,14 @@
 # After the first successful "terraform apply":
 #
 # - uncomment this block
-# - replace the bucket name with the one you set, or the default: github-foundations-tf-state-{{ you_org_id }}
+# - replace the bucket name with the one you set, or the default: github-tf-state-bucket-{{ you_org_id }}
 # - (Optional) If using Azure: Replace the Storage Account name
 # - run "terraform init"
 
 ### GCP ###
 # terraform {
 #   backend "gcs" {
-#     bucket = "github-foundations-tf-state-1234567890"
+#     bucket = "github-tf-state-bucket-1234567890"
 #     prefix = "terraform/github-foundations/bootstrap"
 #   }
 # }
@@ -34,7 +34,7 @@
 #  backend "azurerm" {
 #    resource_group_name  = "StorageAccount-ResourceGroup"
 #    storage_account_name = "replace-me-with-your-storage-account-name"
-#    container_name       = "github-foundations-tf-state-1234567890"
+#    container_name       = "github-tf-state-bucket-1234567890"
 #    key                  = "prod.terraform.tfstate"
 #  }
 # }

--- a/bootstrap/data.tf
+++ b/bootstrap/data.tf
@@ -1,5 +1,6 @@
 locals {
   no_enterprise_account = var.github_enterprise_slug == ""
+  tf_state_bucket_name  = var.tf_state_bucket_name == "" ? format("github-tf-state-bucket-%d", var.org_id) : var.tf_state_bucket_name
 }
 
 data "github_enterprise" "enterprise_account" {

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -19,7 +19,7 @@ module "github_gcloud_oidc" {
   ]
 
   #Bucket
-  bucket_name = "github-tf-state-bucket"
+  bucket_name = local.tf_state_bucket_name
   location    = "northamerica-northeast1"
   versioning  = true
   lifecycle_rules = {

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -58,6 +58,6 @@ variable "github_account_type" {
 
 variable "tf_state_bucket_name" {
   type        = string
-  description = "The name to use for the Cloud storage bucket for storing terraform state. Defaults to 'github-foundations-tf-state-{{ var.org_id }}'."
+  description = "The name to use for the Cloud storage bucket for storing terraform state. Defaults to 'github-tf-state-bucket-{{ var.org_id }}'."
   default     = ""
 }

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -54,6 +54,10 @@ variable "github_account_type" {
     condition     = var.github_account_type == "Personal" || var.github_account_type == "Organization" || var.github_account_type == "Enterprise"
     error_message = "The github_account_type value must be 'Personal', 'Organization', or 'Enterprise'."
   }
+}
 
-
+variable "tf_state_bucket_name" {
+  type        = string
+  description = "The name to use for the Cloud storage bucket for storing terraform state. Defaults to 'github-foundations-tf-state-{{ var.org_id }}'."
+  default     = ""
 }


### PR DESCRIPTION
## ISSUE

[#100] - [Bug] GCP bucket name is hard-coded but must be globally unique

When running the `bootstrap` layer for a new organization the following error occurred:

```
│ Error: googleapi: Error 409: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again., conflict
│ 
│   with module.github_gcloud_oidc.google_storage_bucket.bucket,
│   on .terraform/modules/github_gcloud_oidc/modules/github-gcloud-oidc/storage.tf line 2, in resource "google_storage_bucket" "bucket":
│    2: resource "google_storage_bucket" "bucket" {
│ 
```

The storage bucket name is hardcoded as `github-tf-state-bucket`, which means only the first org to use the toolkit can successfully setup their org.

---