### PR TITLE
chore: ran through azure bootstrap

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,13 +1,13 @@
 # Bootstrap
 
 This layer of the toolkit contains all the terraform needed to:
- 
- 1. Setup a GCP project with secret manager, workfload federated identity for github OIDC and a bucket for terraform state storage.
+
+ 1. Setup a GCP or Azure project with secret management, workload federated identity for github OIDC, and a bucket for terraform state storage.
  2. Setup an organization under a github enterprise account for all the github foundation related repositories.
  3. Perform initial creation of all other organizations under a github enterprise account.
 
  This layer is meant to be run locally by a user that can authenticate with the `admin:enterprise, admin:org, repo, workflow` scopes.
- 
+
 ## System Diagram
 
 ![System Diagram](../resources/images/system_diagram.png)
@@ -45,6 +45,22 @@ The single organization approach can be used with or without GitHub Enterprise. 
 
 The following section will describe how to setup variables to run the bootstrap layer for both a single organization and a multi-organization setup.
 
+### Azure Setup (Optional)
+
+If you are using Azure as your cloud provider, you will need to setup the Azure terraform files.
+
+1. Delete each of these files to:
+    * `main.tf.gcp`
+    * `providers.tf.gcp`
+    * `versions.tf.gcp`
+    They are GCP configuration, and not needed for Azure.
+3. Copy the `azure/main.tf.azure` file into the root of the repository and rename it to `main.tf`.
+4. Copy the `azure/providers.tf.azure` file into the root of the repository and rename it to `providers.tf`.
+5. Copy the `azure/versions.tf.azure` file into the root of the repository and rename it to `versions.tf`.
+6. Copy the `azure/variables-override.tf.azure` file into the root of the repository and rename it to `variables-override.tf`.
+
+
+
 ### Configuring Variables
 
 Before running the bootstrap layer, you need to configure input variables for it to run. You can do this by copying the `terraform.tfvars.example` file to `terraform.tfvars` and filling in the values.
@@ -54,7 +70,7 @@ $ cp terraform.tfvars.example terraform.tfvars
 $ nano terraform.tfvars
 ```
 
-For both a single organization and  multi organization approach the following variables are required:
+For both a single organization and multi organization approach the following variables are required:
 - `org_id`: The id of the gcp organization that will have the project that has the terraform state file bucket(s).
 - `billing_account`: The billing account to use for the gcp project that has teh terraform state file bucket(s).
 - `github_foundations_organization_name`: The name of the organization that will host the github foundation repositories. In the case of the multi-org approach this must be an organization name that doesn't already exist. However for the single org approach this should be the name of an existing organization that you want to use.
@@ -67,6 +83,15 @@ To use the toolkit in a multi-organization approach the following variables are 
 For the multi-organization approach the following variable is optional:
 - `github_enterprise_organizations`: A map of organizations to create under the enterprise account. You can still use the organization layer to manage organizations under your enterprise account that weren't created this way so this is optional.
 
+For any configuration the following are optional:
+- `tf_state_bucket_name`: The name of the bucket to store the terraform state file. If not set a default name will be used.
+- `tf_state_location`: The location of the bucket to store the terraform state file. If not set a default location will be used.
+
+For any configuration, using `Azure` as the cloud provider, the following are optional:
+- `secret_store_name`: The name to use for a secret manager store. To bring your own Azure Key Vault, specify the name of the Azure Key Vault you want to use. If not set, a new Azure Key Vault will be created using a default name.
+- `secret_store_project`: The container / project name where the secrets will be stored. If not set a default name will be used.
+
+
 ## Running the Bootstrap Layer
 
 This section outlines the steps to run the bootstrap layer. Remember to ensure you have met the prerequisites detailed in the previous section before proceeding.
@@ -78,15 +103,45 @@ To run the bootstrap layer perform the following steps:
 1. Clone this repository locally and copy the bootstrap folder into a separate folder on your local machine.
 2. Navigate to the folder that you copied the bootstrap layer to and configure the variables required to run it. For more info on how to do this refer to the [configuring variables section](#configuring-variables).
 3. Run `terraform init` then generate and execute a plan with `terraform apply`. If you run into any authentication issues make sure all [prerequisites are met](#prerequisites-for-running-the-bootstrap-layer).
-4. After a successful application of the terraform code navigate to the `backend.tf` file and uncomment the GCS backend configuration. It should be the block that looks like this:
+      * If using `Azure` for your backend, make a note of the `sa_name` output as you will need it for the next step.
+
+4. After a successful application of the terraform code navigate to the `backend.tf` file and uncomment the backend configuration for your cloud.
+
+---
+
+**GCP**
+
+It should be the block that looks like this:
 ```hcl
 terraform {
   backend "gcs" {
-    bucket = "github-tf-state-bucket"
+    bucket = "ghf-state-1234567890"
     prefix = "terraform/github-foundations/bootstrap"
   }
 }
 ```
+* replace the bucket name with the one you set in the `terraform.tfvars` file, or the default one (`ghf-state-<your-org-id>`) if you didn't set it.
+
+---
+
+**Azure**
+
+It should be the block that looks like this:
+```hcl
+terraform {
+ backend "azurerm" {
+   resource_group_name  = "github-foundations"
+   storage_account_name = "ghfoundations"
+   container_name       = "ghf-state"
+   key                  = "prod.terraform.tfstate"
+ }
+}
+```
+  * replace the `container_name` with the one you set in the `terraform.tfvars` file, or the default one (`ghf-state-`) if you didn't set it.
+  * replace the `storage_account_name` with the name of the `sa_name` output from the previous step.
+
+---
+
 5. Run `terraform init -migrate-state` again, it should ask you if you want to migrate your backend. If you want to suppress the prompt and answer "yes" then add the `-force-copy` option.
 6. Create a pull request and store all the bootstrap layer terraform in to the bootstrap repository that should have been created for you by terraform when you ran `terraform apply`.
 

--- a/bootstrap/azure/main.tf.azure
+++ b/bootstrap/azure/main.tf.azure
@@ -1,57 +1,41 @@
 locals {
   oidc_configuration = {
-    gcp = {
-      workload_identity_provider_name   = module.github_oidc.provider_name
-      bootstrap_workload_identity_sa    = module.github_oidc.bootstrap_sa
-      organization_workload_identity_sa = module.github_oidc.organizations_sa
-      gcp_secret_manager_project_id     = module.github_oidc.project_id
-
-      gcp_tf_state_bucket_project_id = module.github_oidc.project_id
-      bucket_name                    = module.github_oidc.bucket_name
-      bucket_location                = module.github_oidc.bucket_location
-      readme_path                    = ""
+    azure = {
+      bootstrap_client_id    = module.github_oidc.bootstrap_client_id
+      organization_client_id = module.github_oidc.organization_client_id
+      tenant_id              = module.github_oidc.tenant_id
+      subscription_id        = module.github_oidc.subscription_id
+      resource_group_name    = module.github_oidc.resource_group
+      storage_account_name   = module.github_oidc.sa_name
+      container_name         = module.github_oidc.container_name
+      key_vault_id           = module.github_oidc.key_vault_id
     }
   }
+
+  # Set a default state container name if one is not provided
+  az_state_container = var.tf_state_bucket_name == "" ? "ghf-state" : var.tf_state_bucket_name
 }
 
 module "github_oidc" {
-  source = "github.com/FociSolutions/github-foundations-modules//modules/github-gcloud-oidc?ref=v0.0.3"
+  source = "github.com/FociSolutions/github-foundations-modules//modules/github-azure-oidc?ref=v0.0.3"
 
-  #Folder
-  parent      = "organizations/${var.org_id}"
-  folder_name = "fldr-github-foundations"
+  rg_name     = var.tf_state_project
+  rg_create   = true
 
-  #Project
-  billing_account = var.billing_account
-  project_name    = var.tf_state_project
-  prefix          = "prj-g"
-  services = [
-    "storage-api.googleapis.com",
-    "iam.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "iamcredentials.googleapis.com",
-    "sts.googleapis.com",
-    "secretmanager.googleapis.com"
-  ]
+  rg_location = var.tf_state_location
 
-  #Bucket
-  bucket_name = local.tf_state_bucket_name
-  location    = var.tf_state_location
-  versioning  = true
-  lifecycle_rules = {
-    lr-0 = {
-      action = {
-        type = "Delete"
-      }
-      condition = {
-        num_newer_versions = "5"
-      }
-    }
-  }
-  force_destroy = true
+  sa_name                                               = "ghfoundations"
+  sa_tier                                               = "Standard"
+  sa_replication_type                                   = "LRS"
+  tf_state_container                                    = local.az_state_container
+  tf_state_container_anonymous_access_level             = "private"
+  tf_state_container_encryption_scope_override_enabled  = false
 
-  #OIDC Setup
+  kv_resource_group = var.secret_store_project
+  kv_name           = var.secret_store_name
+
   github_foundations_organization_name = var.github_foundations_organization_name
+  drift_detection_branch_name          = "main"
 }
 
 # Github foundations setup

--- a/bootstrap/azure/providers.tf.azure
+++ b/bootstrap/azure/providers.tf.azure
@@ -1,0 +1,12 @@
+provider "azurerm" {
+  features {}
+}
+
+provider "github" {
+  alias = "enterprise_scoped"
+}
+
+provider "github" {
+  alias = "foundation_org_scoped"
+  owner = var.github_foundations_organization_name
+}

--- a/bootstrap/azure/variables-override.tf.azure
+++ b/bootstrap/azure/variables-override.tf.azure
@@ -1,0 +1,11 @@
+variable secret_store_project {
+  type        = string
+  description = "The project/resource group to use for the secret store / key vault."
+  default     = "ghf-secrets-rg"
+}
+
+variable "secret_store_name" {
+  type        = string
+  description = "The name of the secret store / key vault to use."
+  default     = "ghf-secrets"
+}

--- a/bootstrap/azure/versions.tf.azure
+++ b/bootstrap/azure/versions.tf.azure
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.1.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.0.0"
+    }
+  }
+}

--- a/bootstrap/backend.tf
+++ b/bootstrap/backend.tf
@@ -17,14 +17,14 @@
 # After the first successful "terraform apply":
 #
 # - uncomment this block
-# - replace the bucket name with the one you set, or the default: github-tf-state-bucket-{{ you_org_id }}
+# - replace the state bucket/container name with the one you set, or the default.
 # - (Optional) If using Azure: Replace the Storage Account name
 # - run "terraform init"
 
 ### GCP ###
 # terraform {
 #   backend "gcs" {
-#     bucket = "github-tf-state-bucket-1234567890"
+#     bucket = "github-foundations-tf-state-4034205967392"
 #     prefix = "terraform/github-foundations/bootstrap"
 #   }
 # }
@@ -32,9 +32,9 @@
 ### AZURE ###
 # terraform {
 #  backend "azurerm" {
-#    resource_group_name  = "StorageAccount-ResourceGroup"
-#    storage_account_name = "replace-me-with-your-storage-account-name"
-#    container_name       = "github-tf-state-bucket-1234567890"
+#    resource_group_name  = "github-foundations"
+#    storage_account_name = "ghfoundations"
+#    container_name       = "ghf-state"
 #    key                  = "prod.terraform.tfstate"
 #  }
 # }

--- a/bootstrap/terraform.tfvars.template
+++ b/bootstrap/terraform.tfvars.template
@@ -23,3 +23,9 @@ github_enterprise_organizations = {
     #   admin_logins  = ["fred@uncaffeinated.com" ]
     # }
 }
+
+# If using Azure
+# tf_state_location = "Canada East"
+# To bring your own Azure Key Vault, set the following variables
+# secret_store_name = "<REPLACE-ME>"
+# secret_store_project = "ghf-secrets-rg"

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -58,6 +58,18 @@ variable "github_account_type" {
 
 variable "tf_state_bucket_name" {
   type        = string
-  description = "The name to use for the Cloud storage bucket for storing terraform state. Defaults to 'github-tf-state-bucket-{{ var.org_id }}'."
+  description = "The name to use for the Cloud storage bucket for storing terraform state. Defaults to 'ghf-state-{{ var.org_id }}'."
   default     = ""
+}
+
+variable "tf_state_project" {
+  type        = string
+  description = "The project (GCP), or resource group (Azure) to use for the Cloud storage bucket for storing terraform state. Defaults to the project being deployed to."
+  default     = "github-foundations"
+}
+
+variable "tf_state_location" {
+  type        = string
+  description = "The location of the tf_state_project. Defaults to 'northamerica-northeast1'."
+  default     = "northamerica-northeast1"
 }


### PR DESCRIPTION
## ISSUE

[#102] - [Chore] Run through bootstrap setup


In order to confirm the operation, and to make sure the documentation is updated, we ran through a `bootstrap` layer setup for both:

* GCP
* Azure

---


## Changes made

1. Added / modified available configuation variables
2. Created a set of Azure files that can be copy-pasted to use toolkit in "Azure" mode
3. Added instructions on how to setup Azure in the `README.md`

**Note** The `oidc_configuation` was moved to the top of the file in `main.tf`, so that the "parts that change" compared to `azure/main.tf.azure` are all at the top of both files

--- 