### PR TITLE
bug: checks are failing

### DIFF
--- a/organizations/.github/workflows/ghas-policy-check.yaml
+++ b/organizations/.github/workflows/ghas-policy-check.yaml
@@ -29,8 +29,7 @@ jobs:
             - name: Get the list of repos with GHAS enabled
               id: repo_list
               run: |
-                echo "Finding applicable repos in \"${{ github.workspace }}/projects/\""
-                repos=$(./github-foundations-cli list repos --ghas ${{ github.workspace }}/projects/)
+                repos=$(echo $(./github-foundations-cli list repos --ghas ${{ github.workspace }}/projects))
                 echo -e "Found repos: $repos"
                 echo "repos=$(echo -e "${repos}" | sed s/\'/\"/g)" >> $GITHUB_OUTPUT
 

--- a/organizations/.github/workflows/package-audit-logs.yaml
+++ b/organizations/.github/workflows/package-audit-logs.yaml
@@ -25,7 +25,7 @@ jobs:
             - name: Find Orgs
               id: find-orgs-step
               run: |
-                orgs=$(./github-foundations-cli list orgs ${{ github.workspace }}/organizations/)
+                orgs=$(echo $(./github-foundations-cli list orgs ${{ github.workspace }}/providers))
                 echo -e "Found orgs: $orgs"
                 echo "orgs=$(echo -e "${orgs}" | sed s/\'/\"/g)" >> $GITHUB_OUTPUT
 
@@ -48,7 +48,7 @@ jobs:
               uses: FociSolutions/github-foundations/organizations/.github/actions/get-gh-token@main
               with:
                   secret_store: 'gcp'
-                  repo_name: ${{ matrix.repo }}
+                  repo_name: "${{ matrix.org }}/"
                   gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
                   workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
 


### PR DESCRIPTION
### ISSUE

[#106] - [Bug] Two of the checks are failing

The following checks are failing:

* ghas-policy-check
* package-audit-logs

In both cases, the action cannot find any organizations. It appears to be looking in the wrong path, with one extra `/organization` too many:

```
Run orgs=$(./github-foundations-cli list orgs /home/runner/work/organizations/organizations/organizations/)
```

and

```
repos=$(./github-foundations-cli list repos --ghas /home/runner/work/organizations/organizations/projects/)
```

---