### PR TITLE
docs: revised guardrails with new controls

### DIFF
--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -30,6 +30,7 @@ This guardrail document relates to Software as a Service (SaaS), specifically De
 | 06  | [Network security services](./guardrails/EN/06_Network-Security-Services.md) |
 | 07  | [Cyber defense services](./guardrails/EN/07_Cyber-Defense-Services.md) |
 | 08  | [Logging and monitoring](./guardrails/EN/08_Logging-and-Monitoring.md) |
+| 09  | [Plan for Continuity](./guardrails/EN/09_Plan-for-Continuity.md) |
 
 
 ## After the first 30 business days

--- a/guardrails/EN/01_Protect-user-accounts-and-identities.md
+++ b/guardrails/EN/01_Protect-user-accounts-and-identities.md
@@ -5,11 +5,14 @@
 ## Objective
 
 Protect user accounts and identities.
+
 This section contains the Guardrails that address controls in the following areas:
 
 - Access Control (AC)
-- Configuration Management (CM)
+- Awareness and Training (AT)
+- Audit and Accountability (AU)
 - Identification and Authentication (IA)
+- System and Services Acquisition (SA)
 - System Information and Integrity (SI)
 
 ## Mandatory Requirements
@@ -43,4 +46,9 @@ This section contains the Guardrails that address controls in the following area
 
 ## Related security controls from ITSG-33
 
-AC-2, AC-2(3), AC-2(11), AC-3, AC-5, AC-6, AC-6(5), AC-6(10), AC-7, AC-19, AC-20(3), IA-2, IA-2(1), IA-2(2), IA-2(3), IA-2(11), IA-5(1), IA-5(8), SI-4, SI-4(5), SA-4(12), CM-5
+AC-2, AC-2(7), AC-5, AC-6, AC-6(1), AC-6(2), AC-6(5), AC-19,
+AT-3,
+AU-9(4),
+IA-2, IA-2(6), IA-5, IA-5(6),
+SA-4(12),
+SI-4(20)

--- a/guardrails/EN/02_Manage-Role-Access.md
+++ b/guardrails/EN/02_Manage-Role-Access.md
@@ -5,19 +5,26 @@
 ## Objective
 
 Establish access control policies and procedures for management of all accounts at group or role-based levels.
+
 This section contains the Guardrails that address controls in the following areas:
 
 - Access Control (AC)
+- Awareness and Training (AT)
 - Identification and Authentication (IA)
+- Planning (PL)
+- Personnel Security (PS)
+- System and Communications Protection (SC)
+- System and Information Integrity (SI)
 
 
 ## Mandatory Requirements
 
 | Activity | Validation |
 | --- | --- |
-| Implement a mechanism to enforce access authorizations for all user accounts, based on criteria in the Directive on Service and Digital, Appendix G: Standard on Enterprise Information Technology Service Common Configurations, and in [section 3 of the Account Management Configuration Requirements](https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/account.html#cha3) |<ul><li>Demonstrate access configurations and policies are implemented for different classes of users (non-privileged, and privileged users).</li><li>Confirm that the access authorization mechanisms have been implemented to: <ul><li>Uniquely identify and authenticate users to the cloud service</li> <li>Validating that the least privilege role is assigned</li> <li>Validating that Role Based Access is implemented</li> <li>terminate role assignment upon job change or termination</li> <li>Perform periodic reviews of role assignment (minimum yearly)</li> <li>Disable default and dormant accounts</li> <li>Avoid using of user generic accounts.</li> </ul></li><li>Verify that a review of role assignment for root or global administrator accounts is performed at least every 12 months.</li></ul> |
+| Implement a mechanism to enforce access authorizations for all user accounts, based on criteria in the Directive on Service and Digital, Appendix G: Standard on Enterprise Information Technology Service Common Configurations, and in [section 3 of the Account Management Configuration Requirements](https://www.canada.ca/en/government/system/digital-government/policies-standards/enterprise-it-service-common-configurations/account.html#cha3) |<ul><li>Demonstrate access configurations and policies are implemented for different classes of users (non-privileged, and privileged users).</li><li>Confirm that the access authorization mechanisms have been implemented to: <ul><li>Uniquely identify and authenticate users to the cloud service</li> <li>Validate that the least privilege role is assigned</li> <li>Validate that Role Based Access is implemented</li> <li>Terminate role assignment upon job change or termination</li> <li>Perform periodic reviews of role assignment (minimum yearly)</li> <li>Disable default and dormant accounts</li> <li>Avoid using generic user accounts.</li> </ul></li><li>Verify that a review of role assignment for root or global administrator accounts is performed at least every 12 months.</li></ul> |
 | Leverage role-based access and configure for least privilege doing so can include built-in roles or custom roles that have been established with only the minimum number of privileges required to perform the job function. | <ul><li>Demonstrate that built-in roles on the SCM platform are configured for least privilege. Custom roles can be used but a rationale should be documented and approved.</li></ul> |
 | Establish a guest user access policy and procedures that minimize the number of guest users and that manage the life cycle of such accounts so that such accounts are terminated when they are no longer needed. <br><br><p>**Note:** a guest is someone who is not an employee, student or member of your organization (a guest does not have an existing account with the organization’s SCM platform).<p> | <ul><li>Confirm that only required guest user accounts are enabled (according to the business requirements of the service)</li><li>Provide a list of non-organizational users with elevated privileges.</li><li>Verify that reviews of guest access are performed periodically.</li></ul> |
+| Ensure that any security considerations for users or administrators are documented in the organization's security awareness training program. | <ul><li>Provide evidence that security considerations for users are documented in the organization's security awareness training program.</li></ul> |
 
 ## Conditional Requirements
 
@@ -28,6 +35,7 @@ This section contains the Guardrails that address controls in the following area
 | Enforce just-in-time access for privileged user accounts to provide time-based and approval-based role activation to mitigate the risks of excessive, unnecessary or misused access permissions. | <ul><li>Confirm just-in-time access for all privileged user accounts to provide time-based and approval-based role activation.</li></ul> |
 | Enforce attribute-based access control to restrict access based on a combination of authentication factors, such as devices issued and managed by the GC, device compliance, sign-in and user risks, and location | <ul><li>Provide evidence that attribute-based access control mechanisms are in place to restrict access based on attributes or signals, such as authentication factors, devices issued and managed by the GC, device compliance, sign-in and user risks, and location...</li></ul> |
 | <ul><li>Leverage tools, such as privilege access management systems, to enforce access control to privileged functions by configuring roles that require approval for activation</li><li>Choose one or multiple users or groups as delegated approvers</li></ul> | <ul><li>Provide evidence that all role activation for privileged user accounts require approval, and that privilege elevation is temporary (time-bound).</li></ul> |
+| Develop an acceptable use policy, ensure that it is communicated to all users, and ensure that it is enforced. | <ul><li>Provide evidence that an acceptable use policy is in place, communicated to all users, and enforced. Ideally, this policy would be made visible to users of the SCM when using the platform</li></ul> |
 
 ## References
 
@@ -43,4 +51,10 @@ This section contains the Guardrails that address controls in the following area
 
 ## Related security controls from ITSG-33
 
-AC‑2, AC‑2(1), AC‑2(7) AC‑3, AC‑3(7), AC‑3, AC‑4 AC‑5, AC‑6, AC‑6(5), AC-16(2),IA‑2, IA‑2(1), IA‑2(8), IA‑2(11), IA‑4, IA‑5, IA‑5(1), IA‑5(6), IA-8, IA-8(100)
+AC-1, AC‑2, AC‑2(1), AC‑2(7), AC‑2(9), AC‑5, AC‑6, AC‑6(1), AC‑6(2), AC‑6(5), AC-14,
+AT-1, AT-2, AT-2(2), AT-3, AT-4
+IA-1, IA‑2(6), IA-4, IA-4(2), IA-4(3), IA-4(4), IA‑5, IA‑5(3), IA‑5(4), IA‑5(6),
+PL-4,
+PS-1, PS-2, PS-3, PS-3(3), PS-4, PS-5, PS-6, PS-7,
+SC-2,
+SI-4(20)

--- a/guardrails/EN/03_Secure-Endpoints.md
+++ b/guardrails/EN/03_Secure-Endpoints.md
@@ -10,8 +10,9 @@ This section contains the Guardrails that address controls in the following area
 
 - Access Control (AC)
 - Auditing and Accountability (AU)
-- Identification and Authentication (IA)
-- System Information and Integrity (SI)
+- Security Assessment and Authorization (CA)
+- System and Services Acquisition (SA)
+- System and Communications Protection (SC)
 
 ## Mandatory Requirements
 
@@ -19,6 +20,7 @@ This section contains the Guardrails that address controls in the following area
 | --- | --- |
 | The system Monitors and Controls Remote Access Methods | <ul><li>Set, via configuration, the rules around remote access</li><li>Log and audit all remote access</li></ul> |
 | Encryption of Remote Access Sessions | <ul><li>Ensure that all remote access sessions are encrypted</li><li>Ensure that the encryption is in accordance with the GC [Encryption Guidance](https://www.cyber.gc.ca/en/guidance/cryptographic-algorithms-unclassified-protected-protected-b-information-itsp40111)</li></ul> |
+| Document any external connections to your SCM, for example: <ul><li>External connections from the SCM Runner containers to external services</li><li>Any webhooks that are used to trigger SCM workflows</li></ul> | <ul><li>Provide evidence that external connections to your SCM are documented</li><li>List any ports or protocols that are used to access the SCM</li><li>ensure appropriate safeguards are in place for connecting to  (e.g. Unclassified, Low Low (ULL) to Protected B, Medium, Medium (PBMM))</li></ul>|
 
 ## Conditional Requirements
 
@@ -46,4 +48,9 @@ This section contains the Guardrails that address controls in the following area
 
 ## Related security controls from ITSG-33
 
-AC3, AC-3(7), AC-4, AC-5, AC-6, AC6(5), AC-6(10), AC-17(1), AC-17(2), AC-19, AC-20(3), AU-6, AU-12, IA-2, IA-2(1), IA-2(11), IA-4, IA-5, IA-5(1), SC-8, SC-8(1), SI-4
+
+AC-5, AC-6, AC-6(5), AC-17, AC-17(9), AC-19, AC-20, AC-20(1),
+AU-6,
+CA-3, CA-3(3), CA-3(5),
+SA-9(1), SA-9(2), SA-9(4)
+SC-1, SC-7(3), SC-12, SC-12(1), SC-12(2), SC-12(3), SC-17

--- a/guardrails/EN/04_Enterprise-Monitoring-Accounts.md
+++ b/guardrails/EN/04_Enterprise-Monitoring-Accounts.md
@@ -5,12 +5,15 @@
 
 ## Objective
 
-Create role-based account to enable enterprise monitoring and visibility.
+Create role-based accounts to enable enterprise monitoring and visibility.
+
 This section contains the Guardrails that address controls in the following contexts:
 
 - Access Control (AC)
 - Audit and Accountability (AU)
+- Security Assessment and Authorization (CA)
 - Identification and Authentication (IA)
+- Incident Response (IR)
 
 
 ## Mandatory Requirements
@@ -19,7 +22,7 @@ This section contains the Guardrails that address controls in the following cont
 | --- | --- |
 | Create role-based accounts to enable enterprise monitoring and visibility for cloud environments that are procured via the GC Cloud Broker or are included in the scope of centralized guardrails validation. | <ul><li>Verify that roles required to enable visibility in the GC have been provisioned or assigned.</li></ul> |
 | Maintain healthy management of associated roles. | <ul><li>Verify the implementation of controls listed under [Manage Role Access](./02_Manage-Role-Access.md)</li></ul> |
-| Have a plan in place for responding to security incidents detected through monitoring, including roles and responsibilities, communication plans, and recovery procedures. | <ul><li>Provide evidence that a plan is in place for responding to security incidents detected through monitoring, including roles and responsibilities, communication plans, and recovery procedures.</li></ul> |
+| Have a plan in place for responding to security incidents detected through monitoring, including roles and responsibilities, communication plans, and recovery procedures. | <ul><li>Provide evidence that a plan is in place for responding to security incidents detected through monitoring, including roles and responsibilities, communication plans, and recovery procedures.</li><li>The plan should be included and coordinated with the organization's overall incident response plan</ul> |
 
 ## Conditional Requirements
 
@@ -36,4 +39,8 @@ This section contains the Guardrails that address controls in the following cont
 
 ## Related security controls from ITSG-33
 
-AC-2, AC-2(4), AC-3(7), AC-6(5), AC-6(9), AU-2, AU-6, IA-2(1), SI-4(7), SI-10
+AC-1, AC-2, AC-2(1), AC-2(4), AC-2(7), AC-2(9), AC-5, AC-6, AC-6(5),
+AU-1, AU-2, AU-2(3), AU-6, AU-6(1), AU-6(3),
+CA-7,
+IA-1, IA-4, IA-4(2),
+IR-1, IR-2, IR-3, IR-3(2), IR-4, IR-4(3), IR-5, IR-6, IR-6(1), IR-7(1), IR-7(2), IR-8

--- a/guardrails/EN/05_Data-Protection.md
+++ b/guardrails/EN/05_Data-Protection.md
@@ -5,8 +5,12 @@
 ## Objective
 
 Safeguard information and assets hosted in SCMs, from unauthorized access, use, disclosure, modification, disposal, transmission, or destruction throughout their life cycle.
+
 This section contains the Guardrails that address controls in the following contexts:
 
+- Access Control (AC)
+- Audit and Accountability (AU)
+- Incident Response (IR)
 - System and Communications Protection (SC)
 
 ## Data Location Requirements
@@ -22,6 +26,7 @@ This section contains the Guardrails that address controls in the following cont
 | Implement an encryption mechanism to protect the confidentiality and integrity of data when data is at rest in storage.| <ul><li>For SaaS, confirm that the SCM platform has implemented encryption to protect customer data.</li></ul> |
 | Use cryptographic algorithms and protocols approved by Communications Security Establishment Canada (CSE) in accordance with ITSP.40.111 and ITSP.40.062.| <ul><li>Cryptographic algorithms and protocols configurable by the consumer are in accordance with ITSP.40.111 and ITSP.40.062.</li><li>For SaaS, confirm that the CSP has implemented algorithms that align with ITSP.40.111 and ITSP.40.062.</li></ul>|
 | Enforce the use of _Pull Request_ (PR) reviews, and _Protected Branches_ to ensure that code changes are reviewed and approved by at least one other developer before being merged into the main branch.| <ul><li>Confirm that PR reviews are enforced for all code changes being merged into the default branch of the repository (often called _main_, or _develop_).</li></ul> |
+| Plan, develop, and disseminate an information spillage response plan to ensure that data is handled appropriately in the event of a data spillage.| <ul><li>Provide evidence that an information spillage response plan has been developed and disseminated.</li></ul> |
 
 ## Conditional Requirements
 
@@ -29,6 +34,7 @@ This section contains the Guardrails that address controls in the following cont
 | --- | --- |
 | When dealing with personal information in cloud-based environments, seek guidance from privacy and access to information officials within institutions.| <ul><li>Confirm that privacy is part of the departmental software development life cycle.</li></ul> |
 | When available, leverage an appropriate key management system for the cryptographic protection used in cloud-based services, in accordance with the Government of Canada Considerations for the Use of Cryptography in Commercial Cloud Services and the Cyber Centre’s [Guidance on Cloud Service Cryptography (ITSP.50.106)](https://www.cyber.gc.ca/en/guidance/guidance-cloud-service-cryptography-itsp50106). | <ul><li>Confirm that a key management strategy has been adopted for the SCM platform.</li></ul> |
+| When using Public and Private Repositories, keep them separate | <ul><li>Publicly accessible repositories should be separated from private repositories used for internal development by using different organizations, projects, etc.</li></ul> |
 
 ### Self-hosting considerations
 
@@ -51,4 +57,8 @@ This section contains the Guardrails that address controls in the following cont
 
 ## Related security controls from ITSG-33
 
-SC-12, SC-13, SC-17, SC-28, SC-28(1)
+AC-6, AC-17(2), AC-22,
+AU-2,
+CM-3(6),
+IR-7, IR-9, IR-9(1), IR-9(2), IR-9(4),
+SC-12, SC-12(1), SC-12(2), SC-12(3), SC-17

--- a/guardrails/EN/06_Network-Security-Services.md
+++ b/guardrails/EN/06_Network-Security-Services.md
@@ -4,33 +4,34 @@
 
 ## Objective
 
-Establish external and internal network perimeters and monitor network traffic.
+Establish secure connections, and monitor network traffic.
+
+This section contains the Guardrails that address controls in the following contexts:
+
+- Access Control (AC)
+- Authorization (AU)
+- Security Assessment and Authorization (CA)
 
 
 ## Mandatory Requirements
 
 | Activity | Validation |
  --- | --- |
-| Use HTTPS for all network traffic | <ul><li>Ensure that all network traffic to and from the SCM is encrypted.</li></ul> |
-
-## Conditional Requirements
-
-| Activity |    Validation |
-| --- | --- |
-| When using Public and Private Repositories, keep them separate | <ul><li>Publicly accessible repositories should be separated from private repositories used for internal development</li></ul> |
+| Use HTTPS for all network traffic | <ul><li>Demonstrate that all network traffic to and from the SCM is encrypted.</li></ul> |
+| Perform Regular Audits | <ul><li>Regularly audit the connection security configuration of the SCM to ensure it is in accordance with the organizational security architecture.</li></ul> |
 
 ### Self-hosting considerations
 
 | Activity | Validation |
 | --- | --- |
-| Network Segmentation | <ul><li>Ensure that the SCM is hosted on a separate network segment from the internal organizational network.</li></ul> |
-| Using Managed Interfaces | <ul><li>Connect to the SCM only through managed interfaces, such as a VPN or a secure API.</li></ul> |
-| Using Boundary Protection | <ul><li>Use firewalls and other boundary protection devices to control access to the SCM.</li></ul> |
-| Performing Regular Audits | <ul><li>Regularly audit the security configuration of the SCM and the boundary protection devices to ensure they are in accordance with the organizational security architecture.</li></ul> |
+| Use Network Segmentation | <ul><li>Ensure that the SCM is hosted on a separate network segment from the internal organizational network.</li></ul> |
+| Use Managed Interfaces | <ul><li>Connect to the SCM only through managed interfaces, such as a VPN or a secure API.</li></ul> |
+| Use Boundary Protection | <ul><li>Use firewalls and other boundary protection devices to control access to the SCM.</li></ul> |
+| Perform Regular Audits | <ul><li>Regularly audit the security configuration of the SCM and the boundary protection devices to ensure they are in accordance with the organizational security architecture.</li></ul> |
 | Employ Network monitoring tools | <ul><li>Use network monitoring tools to monitor for: <ul><li>unauthorized use of the information system</li><li>attacks and indicators of potential attacks in accordance with monitoring objectives consistent with the GC CSEMP.</li><li>network intrusion</li></ul></li></ul> |
 | Provide system monitoring information to necessary stakeholders | <ul><li>As detailed in the GC CSEMP, provide system monitoring information to the Canadian Centre for Cyber Security (Cyber Centre) and other departmental monitoring organizations.</li></ul> |
 | Heighten the level of information system monitoring activity whenever there is an indication of increased risk to organizational assets. | <ul><li>Monitor the SCM for suspicious activity and respond to incidents in accordance with the organizational incident response plan. </li></ul>|
-|Obtain a legal opinion with regard to system monitoring | <ul><li>Obtain a legal opinion with regard to system monitoring to ensure that it is in compliance with all applicable Government of Canada legislation, and TBS policies.</li></ul> |
+| Obtain a legal opinion with regard to system monitoring | <ul><li>Obtain a legal opinion with regard to system monitoring to ensure that it is in compliance with all applicable Government of Canada legislation, and TBS policies.</li></ul> |
 
 ## References
 
@@ -41,4 +42,6 @@ Establish external and internal network perimeters and monitor network traffic.
 
 ## Related security controls from ITSG-33
 
-SC‑7, SI-4
+AC-19, AC-20(1)
+AU-6,
+CA-3

--- a/guardrails/EN/07_Cyber-Defense-Services.md
+++ b/guardrails/EN/07_Cyber-Defense-Services.md
@@ -5,10 +5,12 @@
 ## Objective
 
 Establish and implement a comprehensive set of cyber defense services for Software as a Service (SaaS) applications, specifically focusing on DevOps and Source Code Management tools.
+
 This section contains the Guardrails that address controls in the following contexts:
 
 - Access Control (AC)
 - Audit and Accountability (AU)
+- Security Assessment and Authorization (CA)
 - Identification and Authentication (IA)
 
 ## Mandatory Requirements
@@ -17,7 +19,6 @@ This section contains the Guardrails that address controls in the following cont
 | --- | --- |
 | Use threat-detection services that monitor for and alert on suspicious activity, such as multiple failed login attempts, unusual data access patterns, or known malicious IP addresses. | <ul><li>Ensure, at a minimum, that the activity is logged and sent to a SIEM (Security Information and Event Management) tool for analysis.</li></ul> |
 | Ensure all changes to the SCM configuration are reviewed and approved by an authorized individual. | <ul><li>Use documented processes to review and approve changes to the SCM configuration</li><li>When using configuration-as-code, Use Pull Requests or Merge Requests to review and approve changes to the SCM configuration.</li></ul> |
-
 
 ## Conditional Requirements
 
@@ -35,8 +36,6 @@ The [GC CSEMP](https://www.canada.ca/en/government/system/digital-government/onl
 | Initial incident report | As soon as possible, and not to exceed 1 hour, after initial detection |
 | Detailed incident report | Within 24 hours after detection |
 
-
-
 ## References
 
 - [Direction on the Secure Use of Commercial Cloud Services: Security Policy Implementation Notice](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/security-identity-management/direction-secure-use-commercial-cloud-services-spin.html) (SPIN) 2017-01, subsection 6.3
@@ -44,4 +43,7 @@ The [GC CSEMP](https://www.canada.ca/en/government/system/digital-government/onl
 
 ## Related security controls from ITSG-33
 
-AC-22, AU-2, AU-6, IA-5(6), IA-5(7)
+AC-22,
+AU-1, AU-2, AU-6,
+CA-7,
+IA-5(6), IA-5(7)

--- a/guardrails/EN/08_Logging-and-Monitoring.md
+++ b/guardrails/EN/08_Logging-and-Monitoring.md
@@ -5,11 +5,15 @@
 ## Objective
 
 Enable logging for the SCM environment and for SCM-based workloads.
+
 This section contains the Guardrails that address controls in the following areas:
 
 - Access Control (AC)
-- Configuration Management (CM)
+- Audit and Accountability (AU)
+- Security Assessment and Authorization (CA)
 - Identification and Authentication (IA)
+- Incident Response (IR)
+- Planning (PL)
 - System Information and Integrity (SI)
 
 
@@ -21,7 +25,7 @@ This section contains the Guardrails that address controls in the following area
 | Ensure that the appropriate contact information is configured so that the SCM service provider can notify the GC organization of incidents they detect. | <ul><li>Confirm that the security contact record within the account should be completed with the details of at least two appropriate information security personnel (if multiple personnel are permitted by the SCM platform).</li></ul> |
 | Enable Secret-scanning and vulnerability scanning. | <ul><li>Turn on automatic secret scanning and vulnerability scanning.</li><li>Implement a solution to monitor for scans requiring action.</li><li>Demonstrate that scan reports are available for review along with scan logs.</li></ul> |
 | Enable dependency scanning. | <ul><li>Confirm that automatic dependency scanning is enabled.</li><li>Implement a solution to monitor for scans requiring action.</li><li>Demonstrate that scan reports are available for review along with scan logs.</li></ul> |
-| Ensure that resources are assigned to monitor SCM-based events | <ul><li>Demonstrate that the monitoring use cases for the SCM platform have been implemented and have been integrated with the overall security monitoring activities being performed by the department (evidence could include monitoring a checklist or a system generated report).</li></ul> |
+| Ensure that resources are assigned to monitor SCM-based events | <ul><li>Demonstrate that the monitoring use cases for the SCM platform have been implemented and have been integrated with the overall security monitoring activities being performed by the department (evidence could include monitoring a checklist or a system generated report).</li><li>Demonstrate that incidents are reported to the appropriate incident response resources</li><li>Have an incident response plan in case of information spillage</li></ul> |
 | Audit the use of privileged functions | <ul><li>Confirm that auditing of the use of privileged functions is enabled for all user accounts.</li></ul> |
 
 
@@ -37,4 +41,10 @@ None
 
 ## Related security controls from ITSG-33
 
-AC-22, AU-2, AU-6, IA-5(6), IA-5(7)
+AC-1, AC-2(1), AC-2(7), AC-5, AC-22,
+AU-1, AU-2, AU-2(3), AU-6, AU-6(1), AU-6(3), AU-9(4),
+CA-7
+IA-5(7),
+IR-1, IR-4, IR-4(3), IR-5, IR-6, IR-6(1), IR-7, IR-7(1),IR-7(2), IR-8, IR-9, IR-9(1), IR-9(2)
+PL-1, PL-2(3)
+SI-1, SI-4(20), SI-5

--- a/guardrails/EN/09_Plan-for-Continuity.md
+++ b/guardrails/EN/09_Plan-for-Continuity.md
@@ -10,6 +10,7 @@ This section contains the Guardrails that address controls in the following cont
 - Access Control (AC)
 - Security Assessment and Authorization (CA)
 - Contingency Planning (CP)
+- Incident Response (IR)
 
 ## Conditional Requirements
 
@@ -33,4 +34,7 @@ This section contains the Guardrails that address controls in the following cont
 
 ## Related security controls from ITSG-33
 
-AC-1, CA-3, CP-1, CP-2, CP-9
+AC-1, AC-2(1),
+CA-3,
+CP-1, CP-2, CP-2(1), CP-2(2), CP-2(5), CP-2(6), CP-2(8), CP-3, CP-4, CP-4(1), CP-4(2), CP-6, CP-6(1), CP-6(2), CP-6(3), CP-7, CP-7(1), CP-7(2), CP-7(3), CP-7(4), CP-8, CP-8(1), CP-8(2), CP-8(3), CP-8(5), CP-9, CP-9(1), CP-9(2), CP-9(3), CP-9(5), CP-9(10), CP-10, CP-10(4)
+IR-1, IR-9(3)


### PR DESCRIPTION
### ISSUE

#105 - [Doc] Updates the Guardrails docs with TBS feedback

Part of the feedback received on the GitHub PBMM Assessment, was that the wrong policy was used to select the correct ITSG controls for assessment.
The original assessment had used a [GoC policy website](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/cloud-services/government-canada-security-control-profile-cloud-based-it-services.html#toc4) that has been replaced by The CCCS' [ITSP.50.105 - Guidance on cloud security assessment and authorization](https://www.cyber.gc.ca/en/guidance/guidance-cloud-security-assessment-and-authorization-itsp50105)

As such, and additional 122 Controls needed to be considered, and new control families needed to be included.

Given the above, the SCM Guardrails needs to be modified to incorporate the newly included controls