### PR TITLE
fix: don't upload to api

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -13,6 +13,7 @@ on:
     - cron: '20 7 * * 2'
   push:
     branches: ["main"]
+  workflow_dispatch:
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -58,7 +59,7 @@ jobs:
           # For private repositories:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
-          publish_results: true
+          publish_results: false
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.


### PR DESCRIPTION
## ISSUE

#114

The newly added [Step Security Harden Runner jobs](https://github.com/step-security/harden-runner) jobs are failing when attempting to sign/upload artifacts:

```
Generating ephemeral keys...
Retrieving signed certificate...

        Note that there may be personally identifiable information associated with this signed artifact.
        This may include the email address associated with the account with which you authenticate.
        This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
2024/07/04 13:12:30 error signing scorecard json results: error signing payload: getting key from Fulcio: verifying SCT: updating local metadata and targets: error updating to TUF remote mirror: invalid key
remote status:{
	"mirror": "https://sigstore-tuf-root.storage.googleapis.com/",
	"metadata": {
		"root.json": {
			"version": 9,
			"len": 6766,
			"expiration": "12 Sep 24 06:53 UTC",
			"error": ""
		},
		"snapshot.json": {
			"version": 147,
			"len": 2302,
			"expiration": "23 Jul 24 16:06 UTC",
			"error": ""
		},
		"targets.json": {
			"version": 9,
			"len": 5478,
			"expiration": "12 Sep 24 06:13 UTC",
			"error": ""
		},
		"timestamp.json": {
			"version": 199,
			"len": 723,
			"expiration": "09 Jul 24 16:06 UTC",
			"error": ""
		}
	}
}
```

---

## ANALYSIS

It appears that this issue is occurring on the step that is uploading the results to the Step Security API. [This will be disabled](https://github.com/ossf/scorecard-action/issues/1362#issuecomment-2053758170).

---